### PR TITLE
Add option to specify timezone of RRD data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ simple micro service for converting your RRD's to web services
 ### examples
 - last 24 hours ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd```
 - epoch date time filter ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400```
-- specify RRD timezone ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400&rrd_timezone=US/Mountain```
+- specify RRD timezone ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400&rrd_timezone=Pacific/Auckland```
   - For a list of compatible timezones, run ``` import pytz; pytz.all_timezones``` in python
 
 ### rrdtool

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ simple micro service for converting your RRD's to web services
 ### examples
 - last 24 hours ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd```
 - epoch date time filter ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400```
+- specify RRD timezone ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400&rrd_timezone=US/Mountain```
+  - For a list of compatible timezones, run ``` import pytz; pytz.all_timezones``` in python
 
 ### rrdtool
 - tested with version 1.7

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -77,7 +77,7 @@ class RRD_parser:
             print(start_time_rrd)
 
             # Convert end_time epoch time to UTC datetime
-            end_time_utc = datetime.datetime.fromtimestamp(self.start_time, tz=pytz.utc)
+            end_time_utc = datetime.datetime.fromtimestamp(self.end_time, tz=pytz.utc)
             # Convert start_time UTC datetime to specified timezone
             end_time_rrd = end_time_utc.astimezone(pytz.timezone(self.rrd_timezone))
             # Convert end_time back to epoch time

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -144,14 +144,19 @@ class RRD_parser:
         collector = defaultdict(dict)
 
         for d in DS_VALUES:
+            print(d)
             r = self.get_rrd_json(ds=d)
+            print(int(r["xport"]["meta"]["start"]))
             master_result["meta"]["start"] = datetime.datetime.fromtimestamp(
                 int(r["xport"]["meta"]["start"])
                 ).strftime(self.time_format)
+            print(master_result["meta"]["start"])
             master_result["meta"]["step"] = r["xport"]["meta"]["step"]
+            print(int(r["xport"]["meta"]["end"]))
             master_result["meta"]["end"] = datetime.datetime.fromtimestamp(
                 int(r["xport"]["meta"]["end"])
                 ).strftime(self.time_format)
+            print(master_result["meta"]["end"])
             master_result["meta"]["rows"] = 0
             master_result["meta"]["data_sources"].append(
                 r["xport"]["meta"]["legend"]["entry"]

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -1,15 +1,17 @@
+import datetime
+import json
+import pytz
+import re
 import subprocess
 import xmltodict
-import json
-import re
+
 from collections import defaultdict
 from itertools import chain
-import datetime
 
 
 class RRD_parser:
 
-    def __init__(self, rrd_file=None, start_time=None, end_time=None):
+    def __init__(self, rrd_file=None, start_time=None, end_time=None, rrd_timezone='UTC'):
         self.rrd_file = rrd_file
         self.ds = None
         self.step = None
@@ -17,8 +19,10 @@ class RRD_parser:
         self.check_dependc()
         self.start_time = start_time
         self.end_time = end_time
+        self.rrd_timezone = rrd_timezone
 
     def check_dependc(self):
+        """ checks rrdtool is installed and version """
         result = subprocess.check_output(
                                         "rrdtool --version",
                                         shell=True
@@ -61,7 +65,11 @@ class RRD_parser:
         
         rrd_xport_command = f"rrdtool xport --step {self.step} DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime"
         if self.start_time:
-            rrd_xport_command = f"rrdtool xport DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime --start {self.start_time} --end {self.end_time}"
+            start_time_local = pytz.utc.localize(datetime.datetime.fromisoformat(self.start_time)).astimezone(pytz.timezone(self.rrd_timezone))
+            start_time_local = start_time_local.strftime("%s")  # Convert to epoch time
+            end_time_local = pytz.utc.localize(datetime.datetime.fromisoformat(self.end_time)).astimezone(pytz.timezone(self.rrd_timezone))
+            end_time_local = end_time_local.strftime("%s")  # Convert to epoch time
+            rrd_xport_command = f"rrdtool xport DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime --start {start_time_local} --end {end_time_local}"
         result = subprocess.check_output(
                                         rrd_xport_command,
                                         shell=True
@@ -78,9 +86,12 @@ class RRD_parser:
         # convert timezones and floats
         for count, temp_obj in enumerate(payload["data"]):
             epoch_time = temp_obj["t"]
-            utc_time = datetime.datetime.fromtimestamp(
-                int(epoch_time)
-                ).strftime(self.time_format)
+            # Convert epoch time to datetime object in rrd_timezone
+            local_datetime = datetime.datetime.fromtimestamp(int(epoch_time), pytz.timezone(self.rrd_timezone)) 
+            # Convert local datetime to UTC
+            utc_datetime = local_datetime.astimezone(pytz.utc)
+            # Format UTC datetime 
+            utc_time = utc_datetime.strftime(self.time_format) 
             payload["data"][count]["t"] = utc_time
             for key in payload["data"][count]:
                 temp_val = ""

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -146,6 +146,7 @@ class RRD_parser:
         for d in DS_VALUES:
             print(d)
             r = self.get_rrd_json(ds=d)
+            print(r["xport"]["data"])
             print(int(r["xport"]["meta"]["start"]))
             master_result["meta"]["start"] = datetime.datetime.fromtimestamp(
                 int(r["xport"]["meta"]["start"])

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -92,6 +92,7 @@ class RRD_parser:
         # replace rrdtool v key with the ds
         replace_val = "\""+ds.lower()+"\": "
         temp_result_one = re.sub("\"v\": ",  replace_val, json_result)
+        print(json.loads(temp_result_one))
         return json.loads(temp_result_one)
 
     def cleanup_payload(self, payload):

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -163,6 +163,8 @@ class RRD_parser:
                 r["xport"]["meta"]["legend"]["entry"]
                 )
 
+            print(master_result["data"])
+            print(r["xport"]["data"]["row"])
             for collectible in chain(
                 master_result["data"], r["xport"]["data"]["row"]
                                     ):

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -73,14 +73,16 @@ class RRD_parser:
             # Convert start_time UTC datetime to specified timezone
             start_time_rrd = start_time_utc.astimezone(pytz.timezone(self.rrd_timezone))
             # Convert start_time back to epoch time
-            start_time_rrd = start_time_rrd.strftime("%s")  
+            start_time_rrd = start_time_rrd.strftime("%s")
+            print(start_time_rrd)
 
             # Convert end_time epoch time to UTC datetime
             end_time_utc = datetime.datetime.fromtimestamp(self.start_time, tz=pytz.utc)
             # Convert start_time UTC datetime to specified timezone
             end_time_rrd = end_time_utc.astimezone(pytz.timezone(self.rrd_timezone))
             # Convert end_time back to epoch time
-            end_time_rrd = end_time_rrd.strftime("%s") 
+            end_time_rrd = end_time_rrd.strftime("%s")
+            print(end_time_rrd)
             
             rrd_xport_command = f"rrdtool xport DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime --start {start_time_rrd} --end {end_time_rrd}"
         result = subprocess.check_output(
@@ -92,7 +94,6 @@ class RRD_parser:
         # replace rrdtool v key with the ds
         replace_val = "\""+ds.lower()+"\": "
         temp_result_one = re.sub("\"v\": ",  replace_val, json_result)
-        print(json.loads(temp_result_one))
         return json.loads(temp_result_one)
 
     def cleanup_payload(self, payload):

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -74,7 +74,6 @@ class RRD_parser:
             start_time_rrd = start_time_utc.astimezone(pytz.timezone(self.rrd_timezone))
             # Convert start_time back to epoch time
             start_time_rrd = start_time_rrd.strftime("%s")
-            print(start_time_rrd)
 
             # Convert end_time epoch time to UTC datetime
             end_time_utc = datetime.datetime.fromtimestamp(self.end_time, tz=pytz.utc)
@@ -82,18 +81,19 @@ class RRD_parser:
             end_time_rrd = end_time_utc.astimezone(pytz.timezone(self.rrd_timezone))
             # Convert end_time back to epoch time
             end_time_rrd = end_time_rrd.strftime("%s")
-            print(end_time_rrd)
             
             rrd_xport_command = f"rrdtool xport DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime --start {start_time_rrd} --end {end_time_rrd}"
+
         result = subprocess.check_output(
                                         rrd_xport_command,
                                         shell=True
                                         ).decode('utf-8')
         json_result = json.dumps(xmltodict.parse(result), indent=4)
-        print(json_result)
+
         # replace rrdtool v key with the ds
         replace_val = "\""+ds.lower()+"\": "
         temp_result_one = re.sub("\"v\": ",  replace_val, json_result)
+        
         return json.loads(temp_result_one)
 
     def cleanup_payload(self, payload):
@@ -147,32 +147,22 @@ class RRD_parser:
         collector = defaultdict(dict)
 
         for d in DS_VALUES:
-            print(d)
             r = self.get_rrd_json(ds=d)
-            print(r["xport"]["data"])
-            print(int(r["xport"]["meta"]["start"]))
             master_result["meta"]["start"] = datetime.datetime.fromtimestamp(
                 int(r["xport"]["meta"]["start"])
                 ).strftime(self.time_format)
-            print(master_result["meta"]["start"])
             master_result["meta"]["step"] = r["xport"]["meta"]["step"]
-            print(int(r["xport"]["meta"]["end"]))
             master_result["meta"]["end"] = datetime.datetime.fromtimestamp(
                 int(r["xport"]["meta"]["end"])
                 ).strftime(self.time_format)
-            print(master_result["meta"]["end"])
             master_result["meta"]["rows"] = 0
             master_result["meta"]["data_sources"].append(
                 r["xport"]["meta"]["legend"]["entry"]
                 )
 
-            print(master_result["data"])
-            print(r["xport"]["data"]["row"])
             for collectible in chain(
                 master_result["data"], r["xport"]["data"]["row"]
                                     ):
-                print(collectible)
-                print(collectible["t"])
                 collector[collectible["t"]].update(collectible.items())
 
         # combine objs, add row_count

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -158,9 +158,10 @@ class RRD_parser:
                 )
 
             for collectible in chain(
-                print(collectible)
                 master_result["data"], r["xport"]["data"]["row"]
                                     ):
+                print(collectible)
+                print(collectible["t"])
                 collector[collectible["t"]].update(collectible.items())
 
         # combine objs, add row_count

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -158,6 +158,7 @@ class RRD_parser:
                 )
 
             for collectible in chain(
+                print(collectible)
                 master_result["data"], r["xport"]["data"]["row"]
                                     ):
                 collector[collectible["t"]].update(collectible.items())

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -65,11 +65,21 @@ class RRD_parser:
         
         rrd_xport_command = f"rrdtool xport --step {self.step} DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime"
         if self.start_time:
-            start_time_local = pytz.utc.localize(datetime.datetime.fromisoformat(self.start_time)).astimezone(pytz.timezone(self.rrd_timezone))
-            start_time_local = start_time_local.strftime("%s")  # Convert to epoch time
-            end_time_local = pytz.utc.localize(datetime.datetime.fromisoformat(self.end_time)).astimezone(pytz.timezone(self.rrd_timezone))
-            end_time_local = end_time_local.strftime("%s")  # Convert to epoch time
-            rrd_xport_command = f"rrdtool xport DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime --start {start_time_local} --end {end_time_local}"
+            # Convert start_time epoch time to UTC datetime
+            start_time_utc = datetime.datetime.fromtimestamp(self.start_time, tz=pytz.utc) 
+            # Convert start_time UTC datetime to specified timezone
+            start_time_rrd = start_time_utc.astimezone(pytz.timezone(self.rrd_timezone))
+            # Convert start_time back to epoch time
+            start_time_rrd = start_time_rrd.strftime("%s")  
+
+            # Convert end_time epoch time to UTC datetime
+            end_time_utc = datetime.datetime.fromtimestamp(self.start_time, tz=pytz.utc)
+            # Convert start_time UTC datetime to specified timezone
+            end_time_rrd = end_time_utc.astimezone(pytz.timezone(self.rrd_timezone))
+            # Convert end_time back to epoch time
+            end_time_rrd = end_time_rrd.strftime("%s") 
+            
+            rrd_xport_command = f"rrdtool xport DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime --start {start_time_rrd} --end {end_time_rrd}"
         result = subprocess.check_output(
                                         rrd_xport_command,
                                         shell=True
@@ -87,9 +97,9 @@ class RRD_parser:
         for count, temp_obj in enumerate(payload["data"]):
             epoch_time = temp_obj["t"]
             # Convert epoch time to datetime object in rrd_timezone
-            local_datetime = datetime.datetime.fromtimestamp(int(epoch_time), pytz.timezone(self.rrd_timezone)) 
+            rrd_datetime = datetime.datetime.fromtimestamp(int(epoch_time), pytz.timezone(self.rrd_timezone)) 
             # Convert local datetime to UTC
-            utc_datetime = local_datetime.astimezone(pytz.utc)
+            utc_datetime = rrd_datetime.astimezone(pytz.utc)
             # Format UTC datetime 
             utc_time = utc_datetime.strftime(self.time_format) 
             payload["data"][count]["t"] = utc_time

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -11,7 +11,7 @@ from itertools import chain
 
 class RRD_parser:
 
-    def __init__(self, rrd_file=None, start_time=None, end_time=None, rrd_timezone='UTC'):
+    def __init__(self, rrd_file=None, start_time=None, end_time=None, rrd_timezone=None):
         self.rrd_file = rrd_file
         self.ds = None
         self.step = None
@@ -19,7 +19,10 @@ class RRD_parser:
         self.check_dependc()
         self.start_time = start_time
         self.end_time = end_time
-        self.rrd_timezone = rrd_timezone
+        if rrd_timezone is None:
+            self.rrd_timezone = "UTC"
+        else:
+            self.rrd_timezone = rrd_timezone
 
     def check_dependc(self):
         """ checks rrdtool is installed and version """

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -88,6 +88,7 @@ class RRD_parser:
                                         shell=True
                                         ).decode('utf-8')
         json_result = json.dumps(xmltodict.parse(result), indent=4)
+        print(json_result)
         # replace rrdtool v key with the ds
         replace_val = "\""+ds.lower()+"\": "
         temp_result_one = re.sub("\"v\": ",  replace_val, json_result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 fastapi==0.59.0
-xmltodict==0.12.0
-pydantic==1.6.1
-uvicorn==0.13.4
-uvloop==0.15.2
 gunicorn==20.0.4
 httptools==0.1.1
+pydantic==1.6.1
+pytz==2024.2
+uvicorn==0.13.4
+uvloop==0.15.2
+xmltodict==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-fastapi==0.59.0
-gunicorn==20.0.4
-httptools==0.1.1
-pydantic==1.6.1
+fastapi==0.115.6
+gunicorn==23.0.0
+httptools==0.6.4
+pydantic==2.10.4
 pytz==2024.2
-uvicorn==0.13.4
-uvloop==0.15.2
-xmltodict==0.12.0
+uvicorn==0.34.0
+uvloop==0.21.0
+xmltodict==0.14.2

--- a/rrdrest.py
+++ b/rrdrest.py
@@ -39,15 +39,15 @@ async def get_rrd(rrd_path: str, epoch_start_time: Optional[int] = None, epoch_e
     if is_file:
         if (epoch_start_time and not epoch_end_time) or (epoch_end_time and not epoch_start_time):
             raise HTTPException(status_code=500, detail="If epoch start or end time is specified both start and end time MUST be specified")
-        try:
-            rr = RRD_parser(
+        #try:
+        rr = RRD_parser(
                             rrd_file=rrd_path,
                             start_time=epoch_start_time,
                             end_time=epoch_end_time,
                             rrd_timezone=rrd_timezone 
                             )
-            r = rr.compile_result()
-            return r
-        except Exception as e:
-            HTTPException(status_code=500, detail=f"{e}")
+        r = rr.compile_result()
+        return r
+        #except Exception as e:
+        #    HTTPException(status_code=500, detail=f"{e}")
     raise HTTPException(status_code=404, detail="RRD not found")

--- a/rrdrest.py
+++ b/rrdrest.py
@@ -1,14 +1,13 @@
+import os
+
 from fastapi import FastAPI, HTTPException
-
 from backend.RRD_parse import RRD_parser
-
 from typing import Optional
 
-import os
 rrd_rest = FastAPI(
     title="RRDReST",
     description="Makes RRD files API-able",
-    version="0.2",
+    version="0.3",
 )
 
 
@@ -17,6 +16,25 @@ rrd_rest = FastAPI(
     summary="Get the data from a RRD file, takes in a rrd file path"
     )
 async def get_rrd(rrd_path: str, epoch_start_time: Optional[int] = None, epoch_end_time: Optional[int] = None):
+    """
+    Fetches data from an RRD file.
+
+    Args:
+        rrd_path: Path to the RRD file.
+        epoch_start_time: Start time in epoch seconds (optional).
+        epoch_end_time: End time in epoch seconds (optional).
+        rrd_timezone: Timezone of the RRD file (optional). If None, assumes UTC.
+
+    Returns:
+        JSON data from the RRD file.
+
+    Raises:
+        HTTPException: 
+            - 404: If the RRD file is not found.
+            - 500: If epoch_start_time or epoch_end_time is specified without the other, 
+                   or if an error occurs during RRD parsing.
+    """
+
     is_file = os.path.isfile(rrd_path)
     if is_file:
         if (epoch_start_time and not epoch_end_time) or (epoch_end_time and not epoch_start_time):
@@ -25,7 +43,8 @@ async def get_rrd(rrd_path: str, epoch_start_time: Optional[int] = None, epoch_e
             rr = RRD_parser(
                             rrd_file=rrd_path,
                             start_time=epoch_start_time,
-                            end_time=epoch_end_time
+                            end_time=epoch_end_time,
+                            rrd_timezone=rrd_timezone 
                             )
             r = rr.compile_result()
             return r

--- a/rrdrest.py
+++ b/rrdrest.py
@@ -39,15 +39,15 @@ async def get_rrd(rrd_path: str, epoch_start_time: Optional[int] = None, epoch_e
     if is_file:
         if (epoch_start_time and not epoch_end_time) or (epoch_end_time and not epoch_start_time):
             raise HTTPException(status_code=500, detail="If epoch start or end time is specified both start and end time MUST be specified")
-        #try:
-        rr = RRD_parser(
+        try:
+            rr = RRD_parser(
                             rrd_file=rrd_path,
                             start_time=epoch_start_time,
                             end_time=epoch_end_time,
                             rrd_timezone=rrd_timezone 
                             )
-        r = rr.compile_result()
-        return r
-        #except Exception as e:
-        #    HTTPException(status_code=500, detail=f"{e}")
+            r = rr.compile_result()
+            return r
+        except Exception as e:
+            HTTPException(status_code=500, detail=f"{e}")
     raise HTTPException(status_code=404, detail="RRD not found")

--- a/rrdrest.py
+++ b/rrdrest.py
@@ -15,7 +15,7 @@ rrd_rest = FastAPI(
     "/",
     summary="Get the data from a RRD file, takes in a rrd file path"
     )
-async def get_rrd(rrd_path: str, epoch_start_time: Optional[int] = None, epoch_end_time: Optional[int] = None):
+async def get_rrd(rrd_path: str, epoch_start_time: Optional[int] = None, epoch_end_time: Optional[int] = None, rrd_timezone: Optional[str] = None):
     """
     Fetches data from an RRD file.
 


### PR DESCRIPTION
Grafana generally expects datasources to be in UTC time.  However, many legacy RRD system, including LibreNMS, write RRD files in whatever timezone the server or application is set to.  This creates a time offset in Grafana that is difficult to deal with.  This PR gives the option to specify a timezone for the RRD data and converts the query filter epochs and the REST output to UTC based on that.