### PR TITLE
Option for Results in Epoch Format 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ simple micro service for converting your RRD's to web services
 ### examples
 - last 24 hours ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd```
 - epoch date time filter ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400```
+- epoch date time filter ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400&epoch_output=true```
 
 ### rrdtool
 - tested with version 1.7

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ simple micro service for converting your RRD's to web services
 ### examples
 - last 24 hours ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd```
 - epoch date time filter ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400```
-- epoch date time filter ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400&epoch_output=true```
+- time output in epoch ```curl 127.0.0.1:9000/?rrd_path=tests/port-id15.rrd&epoch_start_time=1622109000&epoch_end_time=1624787400&epoch_output=true```
 
 ### rrdtool
 - tested with version 1.7

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -69,9 +69,9 @@ class RRD_parser:
         if self.start_time:
             rrd_xport_command = f"rrdtool xport DEF:data={self.rrd_file}:{ds}:AVERAGE XPORT:data:{ds} --showtime --start {self.start_time} --end {self.end_time}"
         result = subprocess.check_output(
-                                        rrd_xport_command,
-                                        shell=True
-                                        ).decode('utf-8')
+            rrd_xport_command,
+            shell=True
+        ).decode('utf-8')
         json_result = json.dumps(xmltodict.parse(result), indent=4)
         # replace rrdtool v key with the ds
         replace_val = "\""+ds.lower()+"\": "

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -15,6 +15,7 @@ class RRD_parser:
         self.rrd_file = rrd_file
         self.ds = None
         self.step = None
+        print(epoch_output)
         if epoch_output:
             self.time_format = "%s"
         else:
@@ -87,6 +88,7 @@ class RRD_parser:
             utc_time = datetime.datetime.fromtimestamp(
                 int(epoch_time), tz=pytz.utc
             ).strftime(self.time_format)
+            print(self.time_format)
             print(utc_time)
             payload["data"][count]["t"] = utc_time
             for key in payload["data"][count]:

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -25,9 +25,9 @@ class RRD_parser:
 
     def check_dependc(self):
         result = subprocess.check_output(
-                                        "rrdtool --version",
-                                        shell=True
-                                        ).decode('utf-8')
+            "rrdtool --version",
+            shell=True
+        ).decode('utf-8')
         if "RRDtool 1." not in result:
             raise Exception("RRDtool version not found, check rrdtool installed")
 
@@ -87,6 +87,7 @@ class RRD_parser:
             utc_time = datetime.datetime.fromtimestamp(
                 int(epoch_time), tz=pytz.utc
             ).strftime(self.time_format)
+            print(utc_time)
             payload["data"][count]["t"] = utc_time
             for key in payload["data"][count]:
                 temp_val = ""

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -1,10 +1,12 @@
+import datetime
+import json
+import pytz
+import re
 import subprocess
 import xmltodict
-import json
-import re
+
 from collections import defaultdict
 from itertools import chain
-import datetime
 
 
 class RRD_parser:
@@ -78,9 +80,10 @@ class RRD_parser:
         # convert timezones and floats
         for count, temp_obj in enumerate(payload["data"]):
             epoch_time = temp_obj["t"]
+            # Convert the epoch time to UTC
             utc_time = datetime.datetime.fromtimestamp(
-                int(epoch_time)
-                ).strftime(self.time_format)
+                int(epoch_time), tz=pytz.utc
+            ).strftime(self.time_format)
             payload["data"][count]["t"] = utc_time
             for key in payload["data"][count]:
                 temp_val = ""

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -15,7 +15,6 @@ class RRD_parser:
         self.rrd_file = rrd_file
         self.ds = None
         self.step = None
-        print(epoch_output)
         if epoch_output:
             self.time_format = "%s"
         else:
@@ -88,8 +87,6 @@ class RRD_parser:
             utc_time = datetime.datetime.fromtimestamp(
                 int(epoch_time), tz=pytz.utc
             ).strftime(self.time_format)
-            print(self.time_format)
-            print(utc_time)
             payload["data"][count]["t"] = utc_time
             for key in payload["data"][count]:
                 temp_val = ""

--- a/backend/RRD_parse.py
+++ b/backend/RRD_parse.py
@@ -11,11 +11,14 @@ from itertools import chain
 
 class RRD_parser:
 
-    def __init__(self, rrd_file=None, start_time=None, end_time=None):
+    def __init__(self, rrd_file=None, start_time=None, end_time=None, epoch_output=False):
         self.rrd_file = rrd_file
         self.ds = None
         self.step = None
-        self.time_format = "%Y-%m-%d %H:%M:%S"
+        if epoch_output:
+            self.time_format = "%s"
+        else:
+            self.time_format = "%Y-%m-%d %H:%M:%S"
         self.check_dependc()
         self.start_time = start_time
         self.end_time = end_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-fastapi==0.59.0
-xmltodict==0.12.0
-pydantic==1.6.1
-uvicorn==0.13.4
-uvloop==0.15.2
-gunicorn==20.0.4
-httptools==0.1.1
+fastapi==0.115.6
+gunicorn==23.0.0
+httptools==0.6.4
+pydantic==2.10.4
+uvicorn==0.34.0
+uvloop==0.21.0
+xmltodict==0.14.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.115.6
 gunicorn==23.0.0
 httptools==0.6.4
 pydantic==2.10.4
+pytz==2024.2
 uvicorn==0.34.0
 uvloop==0.21.0
 xmltodict==0.14.2

--- a/rrdrest.py
+++ b/rrdrest.py
@@ -1,34 +1,43 @@
-from fastapi import FastAPI, HTTPException
+import os
 
 from backend.RRD_parse import RRD_parser
-
+from fastapi import FastAPI, HTTPException
 from typing import Optional
 
-import os
 rrd_rest = FastAPI(
     title="RRDReST",
     description="Makes RRD files API-able",
-    version="0.2",
+    version="0.3",
 )
 
 
 @rrd_rest.get(
     "/",
-    summary="Get the data from a RRD file, takes in a rrd file path"
+    summary="Get the data from a RRD file, takes in a rrd file path",
+    description="Fetches the RRD file data for the specified time range (if provided). "
+                "If epoch times are not provided, the entire data set will be fetched.",
     )
-async def get_rrd(rrd_path: str, epoch_start_time: Optional[int] = None, epoch_end_time: Optional[int] = None):
-    is_file = os.path.isfile(rrd_path)
-    if is_file:
-        if (epoch_start_time and not epoch_end_time) or (epoch_end_time and not epoch_start_time):
-            raise HTTPException(status_code=500, detail="If epoch start or end time is specified both start and end time MUST be specified")
-        try:
-            rr = RRD_parser(
-                            rrd_file=rrd_path,
-                            start_time=epoch_start_time,
-                            end_time=epoch_end_time
-                            )
-            r = rr.compile_result()
-            return r
-        except Exception as e:
-            HTTPException(status_code=500, detail=f"{e}")
-    raise HTTPException(status_code=404, detail="RRD not found")
+async def get_rrd(
+    rrd_path: str,
+    epoch_start_time: Optional[int] = None,
+    epoch_end_time: Optional[int] = None,
+    epoch_output: Optional[bool] = False,
+):
+    # Check if the file exists
+    if not os.path.isfile(rrd_path):
+        raise HTTPException(status_code=404, detail="RRD file not found")
+
+    if (epoch_start_time and not epoch_end_time) or (epoch_end_time and not epoch_start_time):
+            raise HTTPException(status_code=400, detail="If epoch start or end time is specified both start and end time MUST be specified")
+
+    try:
+        rr = RRD_parser(
+            rrd_file=rrd_path,
+            start_time=epoch_start_time,
+            end_time=epoch_end_time,
+            epoch_output=epoch_output
+        )
+        result = rr.compile_result()
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error processing RRD file: {e}")

--- a/rrdrest.py
+++ b/rrdrest.py
@@ -15,7 +15,7 @@ rrd_rest = FastAPI(
     "/",
     summary="Get the data from a RRD file, takes in a rrd file path",
     description="Fetches the RRD file data for the specified time range (if provided). "
-                "If epoch times are not provided, the entire data set will be fetched.",
+                "If epoch times are not provided, the last 24 hour of data will be fetched.",
     )
 async def get_rrd(
     rrd_path: str,


### PR DESCRIPTION
Newer data sources like Infinity can accept time back in epoch and seem to have more consistent results if you just let them handle datetime formatting from that.

Also, applied a UTC tz to the resulting utc_time variable as I was getting inconsistent results from fromtimestamp() with differing system timezones, especially in docker containers.